### PR TITLE
Remove GasUsage webhook subscription

### DIFF
--- a/toonapi/__version__.py
+++ b/toonapi/__version__.py
@@ -1,3 +1,3 @@
 """Asynchronous Python client the Quby ToonAPI."""
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/toonapi/toon.py
+++ b/toonapi/toon.py
@@ -230,12 +230,7 @@ class Toon:
             data={
                 "applicationId": application_id,
                 "callbackUrl": url,
-                "subscribedActions": [
-                    "BoilerErrorInfo",
-                    "GasUsage",
-                    "PowerUsage",
-                    "Thermostat",
-                ],
+                "subscribedActions": ["BoilerErrorInfo", "PowerUsage", "Thermostat"],
             },
         )
 


### PR DESCRIPTION
It seems like `GasUsage` is no longer a valid action to subscribe to when using webhook with the Toon API.

This PR removes it.